### PR TITLE
Fix entry name from npm registry for installation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -20,7 +20,7 @@ And in most of the cases, I didn't want to support all the edge cases or legacy 
 You can install replace-jQuery using npm:
 
 ```sh
-npm install -g replace-jQuery
+npm install -g replace-jquery
 ```
 
 -   Find all jQuery methods from `sample.js` and write vanillaJs alternatives in out.js


### PR DESCRIPTION
I attempted to install the tool using the instructions in the README. When executing "npm install -g replace-jQuery", the response report `'replace-jQuery@*' is not in the npm registry.`. However, "'replace-jquery" and it appears to be authored by @sachinchoolur, but perhaps npm dropped the capitalization.

Regardless, this PR changes the README to allow for installation based on the name in npm.